### PR TITLE
Perbaiki error ESLint di BrainstormingMenu.tsx

### DIFF
--- a/src/components/story-engine/BrainstormingMenu.tsx
+++ b/src/components/story-engine/BrainstormingMenu.tsx
@@ -7,7 +7,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { Sparkles, ArrowRight, RefreshCw } from 'lucide-react';
-import { BackButton } from '@/components/ui/back-button';
 
 interface BrainstormingMenuProps {
   project: StoryProject;


### PR DESCRIPTION
PR ini memperbaiki error ESLint yang masih tersisa di file BrainstormingMenu.tsx:

```
/src/components/story-engine/BrainstormingMenu.tsx
10:10  Error: 'BackButton' is defined but never used.  @typescript-eslint/no-unused-vars
```

Perubahan yang dilakukan:
- Menghapus impor `BackButton` yang tidak digunakan dari file BrainstormingMenu.tsx

Dengan perubahan ini, build di Vercel seharusnya berhasil tanpa error ESLint.

@kugysoul666 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/471bc8a47ca246908fef9b150f83a10b)